### PR TITLE
DOC-2124: update batch api usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # pottriot.de
+
+test test test


### PR DESCRIPTION
The **batch/v1beta1** API version of CronJob is no longer served as of v1.25.

* Migrate manifests and API clients to use the **batch/v1** API version, available since v1.21.
* All existing persisted objects are accessible via the new API
* No notable changes